### PR TITLE
switched a to an an in glulx doc comment

### DIFF
--- a/src/blorb.rs
+++ b/src/blorb.rs
@@ -110,7 +110,7 @@ pub enum Chunk {
 
     /// Identifier: `b"GLUL"`.
     /// Contains Glulx executable.
-    /// This is a executable resource chunk.
+    /// This is an executable resource chunk.
     Glulx{code: Vec<u8>},
 
     /// Identifier: `b"PNG "`.


### PR DESCRIPTION
There was a gramatical error, "a executable", which was fixed to "an executable".