### PR TITLE
Feature/executable code definitions

### DIFF
--- a/src/blorb.rs
+++ b/src/blorb.rs
@@ -153,6 +153,11 @@ pub enum Chunk {
     /// This is an executable resource chunk.
     Agt{code: Vec<u8>},
 
+    /// Identifier: `b"MAGS"`.
+    /// Contains Magnetic Scrolls executable.
+    /// This is an executable resource chunk.
+    MagneticScrolls{code: Vec<u8>},
+
     /// Identifier: `b"PNG "`.
     /// Contains a PNG image.
     /// This is a picture resource chunk.

--- a/src/blorb.rs
+++ b/src/blorb.rs
@@ -118,6 +118,11 @@ pub enum Chunk {
     /// This is an executable resource chunk.
     Glulx{code: Vec<u8>},
 
+    /// Identifier: `b"TAD2"`.
+    /// Contains TADS 2 executable.
+    /// This is an executable resource chunk.
+    Tads2{code: Vec<u8>},
+
     /// Identifier: `b"PNG "`.
     /// Contains a PNG image.
     /// This is a picture resource chunk.

--- a/src/blorb.rs
+++ b/src/blorb.rs
@@ -108,6 +108,11 @@ pub enum Chunk {
     /// This chunk is optional.
     Frontispiece{num: u32},
 
+    /// Identifier: `b"ZCOD"`.
+    /// Contains Z-code executable.
+    /// This is an executable resource chunk.
+    ZCode{code: Vec<u8>},
+
     /// Identifier: `b"GLUL"`.
     /// Contains Glulx executable.
     /// This is an executable resource chunk.

--- a/src/blorb.rs
+++ b/src/blorb.rs
@@ -123,6 +123,11 @@ pub enum Chunk {
     /// This is an executable resource chunk.
     Tads2{code: Vec<u8>},
 
+    /// Identifier: `b"TAD3"`.
+    /// Contains TADS 3 executable.
+    /// This is an executable resource chunk.
+    Tads3{code: Vec<u8>},
+
     /// Identifier: `b"PNG "`.
     /// Contains a PNG image.
     /// This is a picture resource chunk.

--- a/src/blorb.rs
+++ b/src/blorb.rs
@@ -138,6 +138,11 @@ pub enum Chunk {
     /// This is an executable resource chunk.
     Alan{code: Vec<u8>},
 
+    /// Identifier: `b"ADRI"`.
+    /// Contains ADRIFT executable.
+    /// This is an executable resource chunk.
+    Adrift{code: Vec<u8>},
+
     /// Identifier: `b"PNG "`.
     /// Contains a PNG image.
     /// This is a picture resource chunk.

--- a/src/blorb.rs
+++ b/src/blorb.rs
@@ -148,6 +148,11 @@ pub enum Chunk {
     /// This is an executable resource chunk.
     Level9{code: Vec<u8>},
 
+    /// Identifier: `b"AGT "`.
+    /// Contains AGT executable.
+    /// This is an executable resource chunk.
+    Agt{code: Vec<u8>},
+
     /// Identifier: `b"PNG "`.
     /// Contains a PNG image.
     /// This is a picture resource chunk.

--- a/src/blorb.rs
+++ b/src/blorb.rs
@@ -158,6 +158,11 @@ pub enum Chunk {
     /// This is an executable resource chunk.
     MagneticScrolls{code: Vec<u8>},
 
+    /// Identifier: `b"ADVS"`.
+    /// Contains AdvSys executable.
+    /// This is an executable resource chunk.
+    AdvSys{code: Vec<u8>},
+
     /// Identifier: `b"PNG "`.
     /// Contains a PNG image.
     /// This is a picture resource chunk.

--- a/src/blorb.rs
+++ b/src/blorb.rs
@@ -143,6 +143,11 @@ pub enum Chunk {
     /// This is an executable resource chunk.
     Adrift{code: Vec<u8>},
 
+    /// Identifier: `b"LEVE"`.
+    /// Contains Level 9 executable.
+    /// This is an executable resource chunk.
+    Level9{code: Vec<u8>},
+
     /// Identifier: `b"PNG "`.
     /// Contains a PNG image.
     /// This is a picture resource chunk.

--- a/src/blorb.rs
+++ b/src/blorb.rs
@@ -128,6 +128,11 @@ pub enum Chunk {
     /// This is an executable resource chunk.
     Tads3{code: Vec<u8>},
 
+    /// Identifier: `b"HUGO"`.
+    /// Contains Hugo executable.
+    /// This is an executable resource chunk.
+    Hugo{code: Vec<u8>},
+
     /// Identifier: `b"PNG "`.
     /// Contains a PNG image.
     /// This is a picture resource chunk.

--- a/src/blorb.rs
+++ b/src/blorb.rs
@@ -163,6 +163,11 @@ pub enum Chunk {
     /// This is an executable resource chunk.
     AdvSys{code: Vec<u8>},
 
+    /// Identifier: `b"EXEC"`.
+    /// Contains a native executable.
+    /// This is an executable resource chunk.
+    Exec{code: Vec<u8>},
+
     /// Identifier: `b"PNG "`.
     /// Contains a PNG image.
     /// This is a picture resource chunk.

--- a/src/blorb.rs
+++ b/src/blorb.rs
@@ -133,6 +133,11 @@ pub enum Chunk {
     /// This is an executable resource chunk.
     Hugo{code: Vec<u8>},
 
+    /// Identifier: `b"ALAN"`.
+    /// Contains Alan executable.
+    /// This is an executable resource chunk.
+    Alan{code: Vec<u8>},
+
     /// Identifier: `b"PNG "`.
     /// Contains a PNG image.
     /// This is a picture resource chunk.

--- a/src/io.rs
+++ b/src/io.rs
@@ -175,6 +175,7 @@ trait ReadBlorbExt : Read {
     /// the data from the blorb.
     fn read_from_chunk_data(&mut self, meta: ChunkData) -> Result<Chunk> {
         match &meta.id {
+            b"ADRI" => self.read_adrift(meta.len),
             b"ALAN" => self.read_alan(meta.len),
             b"Fspc" => self.read_frontispiece(),
             b"GLUL" => self.read_glulx(meta.len),
@@ -280,6 +281,14 @@ trait ReadBlorbExt : Read {
         let code = self.read_exact_vec(len)?;
         if len & 1 == 1 {self.read_exact(&mut [0x0])?};
         Ok(Chunk::Alan{code: code})
+    }
+
+    /// Read a `Chunk::Adrift` data from the blorb file. Returns
+    /// a `std::io::Error` if the blorb data is not valid.
+    fn read_adrift(&mut self, len: u32) -> Result<Chunk> {
+        let code = self.read_exact_vec(len)?;
+        if len & 1 == 1 {self.read_exact(&mut [0x0])?};
+        Ok(Chunk::Adrift{code: code})
     }
 
     /// Read a `Chunk::Frontispiece` data from the blorb file. Returns

--- a/src/io.rs
+++ b/src/io.rs
@@ -175,6 +175,7 @@ trait ReadBlorbExt : Read {
     /// the data from the blorb.
     fn read_from_chunk_data(&mut self, meta: ChunkData) -> Result<Chunk> {
         match &meta.id {
+            b"ALAN" => self.read_alan(meta.len),
             b"Fspc" => self.read_frontispiece(),
             b"GLUL" => self.read_glulx(meta.len),
             b"HUGO" => self.read_hugo(meta.len),
@@ -271,6 +272,14 @@ trait ReadBlorbExt : Read {
         let code = self.read_exact_vec(len)?;
         if len & 1 == 1 {self.read_exact(&mut [0x0])?};
         Ok(Chunk::Hugo{code: code})
+    }
+
+    /// Read a `Chunk::Alan` data from the blorb file. Returns
+    /// a `std::io::Error` if the blorb data is not valid.
+    fn read_alan(&mut self, len: u32) -> Result<Chunk> {
+        let code = self.read_exact_vec(len)?;
+        if len & 1 == 1 {self.read_exact(&mut [0x0])?};
+        Ok(Chunk::Alan{code: code})
     }
 
     /// Read a `Chunk::Frontispiece` data from the blorb file. Returns

--- a/src/io.rs
+++ b/src/io.rs
@@ -184,6 +184,7 @@ trait ReadBlorbExt : Read {
             b"IFmd" => self.read_metadata(meta.len),
             b"JPEG" => self.read_jpeg(meta.len),
             b"LEVE" => self.read_level9(meta.len),
+            b"MAGS" => self.read_magnetic_scrolls(meta.len),
             b"PNG " => self.read_png(meta.len),
             b"RIdx" => self.read_resource_index(meta.len),
             b"TAD2" => self.read_tads2(meta.len),
@@ -307,6 +308,14 @@ trait ReadBlorbExt : Read {
         let code = self.read_exact_vec(len)?;
         if len & 1 == 1 {self.read_exact(&mut [0x0])?};
         Ok(Chunk::Agt{code: code})
+    }
+
+    /// Read a `Chunk::MagneticScrolls` data from the blorb file. Returns
+    /// a `std::io::Error` if the blorb data is not valid.
+    fn read_magnetic_scrolls(&mut self, len: u32) -> Result<Chunk> {
+        let code = self.read_exact_vec(len)?;
+        if len & 1 == 1 {self.read_exact(&mut [0x0])?};
+        Ok(Chunk::MagneticScrolls{code: code})
     }
 
     /// Read a `Chunk::Frontispiece` data from the blorb file. Returns

--- a/src/io.rs
+++ b/src/io.rs
@@ -176,6 +176,7 @@ trait ReadBlorbExt : Read {
     fn read_from_chunk_data(&mut self, meta: ChunkData) -> Result<Chunk> {
         match &meta.id {
             b"ADRI" => self.read_adrift(meta.len),
+            b"AGT " => self.read_agt(meta.len),
             b"ALAN" => self.read_alan(meta.len),
             b"Fspc" => self.read_frontispiece(),
             b"GLUL" => self.read_glulx(meta.len),
@@ -298,6 +299,14 @@ trait ReadBlorbExt : Read {
         let code = self.read_exact_vec(len)?;
         if len & 1 == 1 {self.read_exact(&mut [0x0])?};
         Ok(Chunk::Level9{code: code})
+    }
+
+    /// Read a `Chunk::Agt` data from the blorb file. Returns
+    /// a `std::io::Error` if the blorb data is not valid.
+    fn read_agt(&mut self, len: u32) -> Result<Chunk> {
+        let code = self.read_exact_vec(len)?;
+        if len & 1 == 1 {self.read_exact(&mut [0x0])?};
+        Ok(Chunk::Agt{code: code})
     }
 
     /// Read a `Chunk::Frontispiece` data from the blorb file. Returns

--- a/src/io.rs
+++ b/src/io.rs
@@ -182,6 +182,7 @@ trait ReadBlorbExt : Read {
             b"PNG " => self.read_png(meta.len),
             b"RIdx" => self.read_resource_index(meta.len),
             b"TAD2" => self.read_tads2(meta.len),
+            b"TAD3" => self.read_tads3(meta.len),
             b"ZCOD" => self.read_zcode(meta.len),
             _ => self.read_unknown(meta),
         }
@@ -253,6 +254,14 @@ trait ReadBlorbExt : Read {
         let code = self.read_exact_vec(len)?;
         if len & 1 == 1 {self.read_exact(&mut [0x0])?};
         Ok(Chunk::Tads2{code: code})
+    }
+
+    /// Read a `Chunk::Tads3` data from the blorb file. Returns
+    /// a `std::io::Error` if the blorb data is not valid.
+    fn read_tads3(&mut self, len: u32) -> Result<Chunk> {
+        let code = self.read_exact_vec(len)?;
+        if len & 1 == 1 {self.read_exact(&mut [0x0])?};
+        Ok(Chunk::Tads3{code: code})
     }
 
     /// Read a `Chunk::Frontispiece` data from the blorb file. Returns

--- a/src/io.rs
+++ b/src/io.rs
@@ -181,6 +181,7 @@ trait ReadBlorbExt : Read {
             b"JPEG" => self.read_jpeg(meta.len),
             b"PNG " => self.read_png(meta.len),
             b"RIdx" => self.read_resource_index(meta.len),
+            b"ZCOD" => self.read_zcode(meta.len),
             _ => self.read_unknown(meta),
         }
     }
@@ -227,6 +228,14 @@ trait ReadBlorbExt : Read {
         let entries = entries;
 
         Ok(Chunk::ResourceIndex{index: ResourceIndex{entries: entries}})
+    }
+
+    /// Read a `Chunk::ZCode` data from the blorb file. Returns
+    /// a `std::io::Error` if the blorb data is not valid.
+    fn read_zcode(&mut self, len: u32) -> Result<Chunk> {
+        let code = self.read_exact_vec(len)?;
+        if len & 1 == 1 {self.read_exact(&mut [0x0])?};
+        Ok(Chunk::ZCode{code: code})
     }
 
     /// Read a `Chunk::Glulx` data from the blorb file. Returns

--- a/src/io.rs
+++ b/src/io.rs
@@ -179,6 +179,7 @@ trait ReadBlorbExt : Read {
             b"ADVS" => self.read_adv_sys(meta.len),
             b"AGT " => self.read_agt(meta.len),
             b"ALAN" => self.read_alan(meta.len),
+            b"EXEC" => self.read_exec(meta.len),
             b"Fspc" => self.read_frontispiece(),
             b"GLUL" => self.read_glulx(meta.len),
             b"HUGO" => self.read_hugo(meta.len),
@@ -325,6 +326,14 @@ trait ReadBlorbExt : Read {
         let code = self.read_exact_vec(len)?;
         if len & 1 == 1 {self.read_exact(&mut [0x0])?};
         Ok(Chunk::AdvSys{code: code})
+    }
+
+    /// Read a `Chunk::Exec` data from the blorb file. Returns
+    /// a `std::io::Error` if the blorb data is not valid.
+    fn read_exec(&mut self, len: u32) -> Result<Chunk> {
+        let code = self.read_exact_vec(len)?;
+        if len & 1 == 1 {self.read_exact(&mut [0x0])?};
+        Ok(Chunk::Exec{code: code})
     }
 
     /// Read a `Chunk::Frontispiece` data from the blorb file. Returns

--- a/src/io.rs
+++ b/src/io.rs
@@ -181,6 +181,7 @@ trait ReadBlorbExt : Read {
             b"JPEG" => self.read_jpeg(meta.len),
             b"PNG " => self.read_png(meta.len),
             b"RIdx" => self.read_resource_index(meta.len),
+            b"TAD2" => self.read_tads2(meta.len),
             b"ZCOD" => self.read_zcode(meta.len),
             _ => self.read_unknown(meta),
         }
@@ -244,6 +245,14 @@ trait ReadBlorbExt : Read {
         let code = self.read_exact_vec(len)?;
         if len & 1 == 1 {self.read_exact(&mut [0x0])?};
         Ok(Chunk::Glulx{code: code})
+    }
+
+    /// Read a `Chunk::Tads2` data from the blorb file. Returns
+    /// a `std::io::Error` if the blorb data is not valid.
+    fn read_tads2(&mut self, len: u32) -> Result<Chunk> {
+        let code = self.read_exact_vec(len)?;
+        if len & 1 == 1 {self.read_exact(&mut [0x0])?};
+        Ok(Chunk::Tads2{code: code})
     }
 
     /// Read a `Chunk::Frontispiece` data from the blorb file. Returns

--- a/src/io.rs
+++ b/src/io.rs
@@ -176,6 +176,7 @@ trait ReadBlorbExt : Read {
     fn read_from_chunk_data(&mut self, meta: ChunkData) -> Result<Chunk> {
         match &meta.id {
             b"ADRI" => self.read_adrift(meta.len),
+            b"ADVS" => self.read_adv_sys(meta.len),
             b"AGT " => self.read_agt(meta.len),
             b"ALAN" => self.read_alan(meta.len),
             b"Fspc" => self.read_frontispiece(),
@@ -316,6 +317,14 @@ trait ReadBlorbExt : Read {
         let code = self.read_exact_vec(len)?;
         if len & 1 == 1 {self.read_exact(&mut [0x0])?};
         Ok(Chunk::MagneticScrolls{code: code})
+    }
+
+    /// Read a `Chunk::AdvSys` data from the blorb file. Returns
+    /// a `std::io::Error` if the blorb data is not valid.
+    fn read_adv_sys(&mut self, len: u32) -> Result<Chunk> {
+        let code = self.read_exact_vec(len)?;
+        if len & 1 == 1 {self.read_exact(&mut [0x0])?};
+        Ok(Chunk::AdvSys{code: code})
     }
 
     /// Read a `Chunk::Frontispiece` data from the blorb file. Returns

--- a/src/io.rs
+++ b/src/io.rs
@@ -182,6 +182,7 @@ trait ReadBlorbExt : Read {
             b"HUGO" => self.read_hugo(meta.len),
             b"IFmd" => self.read_metadata(meta.len),
             b"JPEG" => self.read_jpeg(meta.len),
+            b"LEVE" => self.read_level9(meta.len),
             b"PNG " => self.read_png(meta.len),
             b"RIdx" => self.read_resource_index(meta.len),
             b"TAD2" => self.read_tads2(meta.len),
@@ -289,6 +290,14 @@ trait ReadBlorbExt : Read {
         let code = self.read_exact_vec(len)?;
         if len & 1 == 1 {self.read_exact(&mut [0x0])?};
         Ok(Chunk::Adrift{code: code})
+    }
+
+    /// Read a `Chunk::Level9` data from the blorb file. Returns
+    /// a `std::io::Error` if the blorb data is not valid.
+    fn read_level9(&mut self, len: u32) -> Result<Chunk> {
+        let code = self.read_exact_vec(len)?;
+        if len & 1 == 1 {self.read_exact(&mut [0x0])?};
+        Ok(Chunk::Level9{code: code})
     }
 
     /// Read a `Chunk::Frontispiece` data from the blorb file. Returns

--- a/src/io.rs
+++ b/src/io.rs
@@ -177,6 +177,7 @@ trait ReadBlorbExt : Read {
         match &meta.id {
             b"Fspc" => self.read_frontispiece(),
             b"GLUL" => self.read_glulx(meta.len),
+            b"HUGO" => self.read_hugo(meta.len),
             b"IFmd" => self.read_metadata(meta.len),
             b"JPEG" => self.read_jpeg(meta.len),
             b"PNG " => self.read_png(meta.len),
@@ -262,6 +263,14 @@ trait ReadBlorbExt : Read {
         let code = self.read_exact_vec(len)?;
         if len & 1 == 1 {self.read_exact(&mut [0x0])?};
         Ok(Chunk::Tads3{code: code})
+    }
+
+    /// Read a `Chunk::Hugo` data from the blorb file. Returns
+    /// a `std::io::Error` if the blorb data is not valid.
+    fn read_hugo(&mut self, len: u32) -> Result<Chunk> {
+        let code = self.read_exact_vec(len)?;
+        if len & 1 == 1 {self.read_exact(&mut [0x0])?};
+        Ok(Chunk::Hugo{code: code})
     }
 
     /// Read a `Chunk::Frontispiece` data from the blorb file. Returns


### PR DESCRIPTION
This adds `Chunk` variants for the remaining executable types specified in the blorb spec.
This resolves #13, #14, #15, #16, #17, #18, #19, #20, #21, #22, #23.